### PR TITLE
Fix variable naming typo

### DIFF
--- a/c2c_test/grouped_16/app.py
+++ b/c2c_test/grouped_16/app.py
@@ -31,7 +31,7 @@ def call_someone():
     )
 
 
-DEFAULT_BARNCHES = [
+DEFAULT_BRANCHES = [
     [
         Or(
             Txn.on_completion() == OnComplete.UpdateApplication,
@@ -45,7 +45,7 @@ DEFAULT_BARNCHES = [
 
 APPROVAL = Cond(
     [Txn.application_id() == Int(0), Approve()],
-    *DEFAULT_BARNCHES,
+    *DEFAULT_BRANCHES,
     [Txn.application_args.length() > Int(0), Return(call_someone())],
     [Txn.on_completion() == OnComplete.NoOp, Return(log_caller())]
 )

--- a/c2c_test/inner_256/app.py
+++ b/c2c_test/inner_256/app.py
@@ -44,7 +44,7 @@ def callecho():
     )
 
 
-DEFAULT_BARNCHES = [
+DEFAULT_BRANCHES = [
     [
         Or(
             Txn.on_completion() == OnComplete.UpdateApplication,
@@ -67,14 +67,14 @@ APPROVAL_ECHO = Cond(
         Txn.application_id() == Int(0),
         Seq(App.globalPut(Bytes("counter"), Int(0)), Approve()),
     ],
-    *DEFAULT_BARNCHES,
+    *DEFAULT_BRANCHES,
     [Txn.on_completion() == OnComplete.NoOp, Return(echo())],
 )
 
 
 APPROVAL_CALL = Cond(
     [Txn.application_id() == Int(0), Approve()],
-    *DEFAULT_BARNCHES,
+    *DEFAULT_BRANCHES,
     [
         Txn.on_completion() == OnComplete.NoOp,
         Return(callecho()),


### PR DESCRIPTION
Provide a minor change to fix what looks like a variable naming typo.  Feel welcomed to close if you prefer to keep as is.